### PR TITLE
feat(repo): update documents, add a starter example

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(wc -l /c/Users/iwank/Documents/github/threadpool-fp/src/*.pas)"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.5.0] - 2026-04-13
+
+### Added
+
+- `examples/Starter/Starter.lpr` — a heavily-commented "Hello, ThreadPool" entry point for new users; includes compile instructions and expected output in the file header
+- README: decision flowchart for choosing `ThreadPool.Simple` vs `ThreadPool.ProducerConsumer`
+- README: Queue overload reference table documenting all 4 `Queue` signatures side-by-side with use-cases and examples
+- README: **Common Mistakes** section covering the four most frequent pitfalls (free-before-WaitForAll, missing WaitForAll, LastError overwrites, manual free of GlobalThreadPool)
+- README: compilation sanity-check section with `fpc` and `lazbuild` one-liners, expected output, and `{$mode objfpc}{$H+}` reminder
+- README: `LastError` overwrite warning — clarifies only the last exception per pool cycle is stored
+- `{$REGION}` / `{$ENDREGION}` grouping in `ThreadPool.Simple.pas` (Public API, Internal Worker Thread, Internal Work Item, Global instance)
+- `{$REGION}` / `{$ENDREGION}` grouping in `ThreadPool.ProducerConsumer.pas` (Public API, Internal Worker Thread, Internal Work Item, Internal Queue, DebugLog)
+- Object lifetime `WARNING` comments in `SimpleDemo.lpr` and `ProdConSimpleDemo.lpr` explaining why objects must not be freed before `WaitForAll`
+
+### Fixed
+
+- `Test07_ParallelExecution`: removed `LogTest` calls from `IncrementCounter` — 2 000 serialised `WriteLn` calls across 1 000 tasks were the bottleneck, consistently exceeding the timing assertion; these calls were present since the test was first written
+- `Test08_QueueFullBehavior`: replaced `SlowTask` (250 ms) with `LongTask` (5 000 ms) so the single worker cannot drain the 2-slot queue before the third enqueue — the race condition was present since the test was first written
+- `Test12_LoadFactorCalculation`: increased queued task count from 2 to 50 — `LoadFactor` drops to 0 the moment `TryDequeue` succeeds (not when execution finishes), so 4+ workers racing to dequeue 2 tasks left the queue empty before the assertion ran; the flaw was present since the test was first written
+
+## [0.4.0] - 2024-xx-xx
+
+### Added
+
+- `ThreadPool.ProducerConsumer` — second thread pool implementation with fixed-size circular queue (default 1 024 items) and built-in backpressure
+- Configurable `TBackpressureConfig` record (load thresholds, adaptive delays, max retry attempts)
+- `EQueueFullException` raised when queue remains full after all retry attempts
+- `TThreadSafeQueue` with `LoadFactor`, `TryEnqueue`, `TryDequeue`
+- `WorkQueue` property on `TProducerConsumerThreadPool` for monitoring and configuration
+- 3 new Producer-Consumer examples: `ProdConSimpleDemo`, `ProdConSquareNumbers`, `ProdConMessageProcessor`
+- API and technical documentation for `ThreadPool.ProducerConsumer`
+- Documentation: Interface Reference Counting and Object Lifetime Management in FPC
+- Lazarus package (`package/lazarus/threadpool_fp.lpk`)
+
+### Fixed
+
+- Incorrect freeing of work items in `ThreadPool.ProducerConsumer`
+- Double decrement of work item counter
+- Race condition in exception propagation from worker threads
+
+## [0.3.0] - 2024-xx-xx
+
+### Added
+
+- `ThreadPool.Types` unit — shared interfaces (`IThreadPool`, `IWorkItem`, `IWorkerThread`) and base class `TThreadPoolBase`
+- Thread count safety limits: minimum 4 threads, maximum 2× `ProcessorCount`
+- `ClearLastError` method on all pool implementations
+- Comprehensive unit tests for `ThreadPool.Simple`
+
+### Changed
+
+- Refactored `ThreadPool.Simple` onto the new `TThreadPoolBase` class
+- Improved method names in unit tests
+
+### Fixed
+
+- Race condition in error handling in `ThreadPool.Simple`
+
+## [0.2.0] - 2024-xx-xx
+
+### Added
+
+- Thread count safety: enforced minimum and maximum bounds
+- Technical documentation and sequence diagrams
+- `SimpleWordCounter` and `SimpleSquareNumbers` examples
+
+### Changed
+
+- Improved comments in the interface section of the unit
+
+## [0.1.0] - 2024-xx-xx
+
+### Added
+
+- Initial implementation of `ThreadPool.Simple` with global `GlobalThreadPool` singleton
+- 4 `Queue` overloads: plain procedure, object method, indexed procedure, indexed method
+- `WaitForAll` and `LastError` / `ClearLastError`
+- `SimpleDemo` and `SimpleThreadpoolDemo` examples
+- MIT licence

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # 🚀 ThreadPool for Free Pascal
 
-![Version](https://img.shields.io/badge/version-0.5.0-blue)
+[![Version](https://img.shields.io/badge/version-0.5.0-8B5CF6.svg)](CHANGELOG.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-1E3A8A.svg)](https://opensource.org/licenses/MIT)
+[![Free Pascal](https://img.shields.io/badge/Free%20Pascal-3.2.2+-3B82F6.svg)](https://www.freepascal.org/)
+[![Lazarus](https://img.shields.io/badge/Lazarus-4.0+-60A5FA.svg)](https://www.lazarus-ide.org/)
+![Supports Windows](https://img.shields.io/badge/support-Windows-F59E0B?logo=Windows)
+![Supports Linux](https://img.shields.io/badge/support-Linux-F59E0B?logo=Linux)
+![No Dependencies](https://img.shields.io/badge/dependencies-none-10B981.svg)
+![Tests](https://img.shields.io/badge/tests-35%20passed-10B981.svg)
+[![Documentation](https://img.shields.io/badge/Docs-Available-brightgreen.svg)](docs/)
+[![Status](https://img.shields.io/badge/Status-Experimental-F59E0B.svg)](README.md)
 
 A lightweight, easy-to-use thread pool implementation for Free Pascal. Simplify parallel processing for simple tasks! ⚡
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![No Dependencies](https://img.shields.io/badge/dependencies-none-10B981.svg)
 ![Tests](https://img.shields.io/badge/tests-35%20passed-10B981.svg)
 [![Documentation](https://img.shields.io/badge/Docs-Available-brightgreen.svg)](docs/)
-[![Status](https://img.shields.io/badge/Status-Experimental-F59E0B.svg)](README.md)
+[![Status](https://img.shields.io/badge/Status-Stable-10B981.svg)](README.md)
 
 A lightweight, easy-to-use thread pool implementation for Free Pascal. Simplify parallel processing for simple tasks! ⚡
 
@@ -18,9 +18,9 @@ A lightweight, easy-to-use thread pool implementation for Free Pascal. Simplify 
 > Parallel processing can improve performance for CPU-intensive tasks that can be executed independently. However, not all tasks benefit from parallelization. See [Thread Management](#-thread-management) for important considerations.
 
 > [!NOTE]
-> This library is an experimental project, as I was exploring the concept of thread pools and how to implement them in Free Pascal.
-> 
-> Hence, this library is **not suitable** for high-load applications. It is designed for simple parallel processing tasks that can be executed in parallel.
+> This library was originally written to explore the concept of thread pools in Free Pascal. It has since grown into a stable, tested implementation suitable for simple parallel processing tasks.
+>
+> It is **not designed** for high-load or production-scale applications. For those use cases, see the alternatives below.
 
 > [!TIP]
 > 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🚀 ThreadPool for Free Pascal
 
+![Version](https://img.shields.io/badge/version-0.5.0-blue)
+
 A lightweight, easy-to-use thread pool implementation for Free Pascal. Simplify parallel processing for simple tasks! ⚡
 
 > [!IMPORTANT]
@@ -52,6 +54,7 @@ A lightweight, easy-to-use thread pool implementation for Free Pascal. Simplify 
   - [🚧 Planned/In Progress](#-plannedin-progress)
   - [👏 Acknowledgments](#-acknowledgments)
   - [📄 License](#-license)
+  - [📋 Changelog](CHANGELOG.md)
 
 ## ✨ Features
 
@@ -252,6 +255,16 @@ end.
 > - 📊 Queue capacity monitoring available
 
 
+### Which implementation should I use?
+
+```text
+Need a thread pool?
+├─ Tasks are fire-and-forget, count is predictable, low overhead wanted?
+│  └─ → Use ThreadPool.Simple (or the GlobalThreadPool singleton)
+└─ Producer can outpace consumers, or you need queue overflow control?
+   └─ → Use ThreadPool.ProducerConsumer
+```
+
 **Use Simple Thread Pool when:**
 - Direct task execution without queuing needed
 - Task count is predictable and moderate
@@ -266,8 +279,29 @@ end.
 - Need detailed execution monitoring
 - Want configurable retry mechanisms
 
+### Queue overload reference
+
+All four `Queue` overloads share the same pattern — pick the one that fits your task:
+
+| Overload | Signature | Use when | Example |
+| --- | --- | --- | --- |
+| Plain procedure | `Queue(@MyProc)` | Standalone procedure, no shared state needed | File I/O, independent calculations |
+| Object method | `Queue(@MyObj.MyMethod)` | Task needs access to object fields/state | Counter objects, result accumulators |
+| Indexed procedure | `Queue(@MyProc, i)` | Loop parallelism over an array/range | `for i := 0 to N-1 do Queue(@Proc, i)` |
+| Indexed method | `Queue(@MyObj.MyMethod, i)` | Loop parallelism + object state | Parallel array transform on an object |
+
+> [!NOTE]
+> `LastError` is **overwritten** (not appended) each time a task raises an exception. If you queue multiple tasks, only the last error is stored. Check `LastError` immediately after `WaitForAll` and call `ClearLastError` before reusing the pool.
+
 
 ## 📚 Examples
+
+### Getting Started
+
+1. 👋 **Starter** (`examples/Starter/Starter.lpr`)
+   - The absolute minimum to compile and run
+   - Heavily commented — every line explained
+   - Best first file to read before the other examples
 
 ### Simple Thread Pool Examples
 
@@ -330,6 +364,40 @@ end.
    - Simple: Use `GlobalThreadPool` or create `TSimpleThreadPool`
    - Producer-Consumer: Create `TProducerConsumerThreadPool`
 
+### Verify your setup
+
+Compile and run the simplest demo from the command line to confirm everything is wired up correctly:
+
+```bash
+# Using the Free Pascal compiler directly
+fpc -Fu./src examples/SimpleDemo/SimpleDemo.lpr && ./SimpleDemo
+
+# Or build with Lazarus from the command line
+lazbuild examples/SimpleDemo/SimpleDemo.lpi && ./SimpleDemo
+```
+
+Expected output (order may vary — tasks run in parallel):
+
+```text
+Demo of ThreadPool functionality:
+--------------------------------
+1. Queueing simple procedure
+2. Queueing method of a class
+3. Queueing indexed procedure
+4. Queueing method with index of a class
+--------------------------------
+Waiting for all tasks to complete...
+Simple procedure executed
+Method executed
+Indexed procedure executed with index: 1
+Method with index executed: 2
+--------------------------------
+All tasks completed successfully!
+```
+
+> [!TIP]
+> Make sure your source file starts with `{$mode objfpc}{$H+}`. Without this, Free Pascal defaults to TP/Delphi-7 mode and some syntax will not compile.
+
 ## ⚙️ Requirements
 
 - 💻 Free Pascal 3.2.2 or later
@@ -373,6 +441,72 @@ May take up to 5 mins to run all tests.
 - Graceful overflow management
 
 
+## ⚠️ Common Mistakes
+
+### 1. Freeing an object before `WaitForAll`
+
+```pascal
+// WRONG — MyObject may be freed while worker threads are still calling its methods
+MyObject := TMyClass.Create;
+GlobalThreadPool.Queue(@MyObject.DoWork);
+MyObject.Free;          // freed too early!
+GlobalThreadPool.WaitForAll;
+
+// CORRECT — always wait before freeing
+MyObject := TMyClass.Create;
+try
+  GlobalThreadPool.Queue(@MyObject.DoWork);
+  GlobalThreadPool.WaitForAll;  // wait first
+finally
+  MyObject.Free;        // safe to free now
+end;
+```
+
+### 2. Forgetting `WaitForAll`
+
+Without `WaitForAll`, your program may exit (and destroy the pool) while tasks are still running, causing access violations or silent data loss.
+
+```pascal
+// WRONG
+for i := 0 to 99 do
+  GlobalThreadPool.Queue(@ProcessItem, i);
+// program exits here, tasks may never finish
+
+// CORRECT
+for i := 0 to 99 do
+  GlobalThreadPool.Queue(@ProcessItem, i);
+GlobalThreadPool.WaitForAll;
+```
+
+### 3. Only the last error is kept
+
+`LastError` is overwritten on every exception — not appended. If multiple tasks fail, you only see the last one.
+
+```pascal
+// Queue several tasks that might fail
+for i := 0 to 9 do
+  Pool.Queue(@RiskyProc, i);
+Pool.WaitForAll;
+
+// Only the LAST exception is in LastError
+if Pool.LastError <> '' then
+  WriteLn('At least one task failed: ', Pool.LastError);
+Pool.ClearLastError;
+```
+
+### 4. Freeing the global pool manually
+
+`GlobalThreadPool` is managed by the unit's `initialization`/`finalization` blocks. Do **not** call `GlobalThreadPool.Free` — let the runtime clean it up.
+
+```pascal
+// WRONG
+GlobalThreadPool.Free;  // double-free at program exit!
+
+// CORRECT — just use it; finalization handles cleanup
+GlobalThreadPool.Queue(@MyProc);
+GlobalThreadPool.WaitForAll;
+```
+
 ## 🚧 Planned/In Progress
 - Adaptive thread adjustment based on a load factor
 - Support for `procedure Queue(AMethod: TProc; AArgs: array of Const);`
@@ -390,6 +524,10 @@ Special thanks to the Free Pascal and Lazarus communities and the creators of th
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) file for details.
+
+## 📋 Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 
 ---
 

--- a/docs/Interface-Reference-Counting-and-Object-Lifetime-Management-in-FPC.md
+++ b/docs/Interface-Reference-Counting-and-Object-Lifetime-Management-in-FPC.md
@@ -102,13 +102,14 @@ var
 begin
   TestPool := TProducerConsumerThreadPool.Create(THREAD_COUNT, QUEUE_SIZE);
   try
-    // Fill queue to capacity
-    TestPool.Queue(@SlowTask);
-    TestPool.Queue(@SlowTask);
-    
+    // Fill queue to capacity with long-running tasks so the worker cannot
+    // drain the queue before the third enqueue is attempted.
+    TestPool.Queue(@LongTask);
+    TestPool.Queue(@LongTask);
+
     // This should trigger the exception
     try
-      TestPool.Queue(@SlowTask);  // Queue is full, will raise exception
+      TestPool.Queue(@LongTask);  // Queue is full, will raise EQueueFullException
     except
       on E: EQueueFullException do
         ExceptionRaised := True;

--- a/docs/ThreadPool.ProducerConsumer-API.md
+++ b/docs/ThreadPool.ProducerConsumer-API.md
@@ -1,44 +1,130 @@
-# 📚 ThreadPool.ProducerConsumer API
+# ThreadPool.ProducerConsumer API Documentation
 
-## 🔧 Core Components
+## Overview
 
-### Thread Pool Types
+`ThreadPool.ProducerConsumer` implements a thread pool backed by a fixed-size
+circular queue with built-in backpressure. Use it when task production can
+outpace consumption and you need predictable memory usage and overflow control.
 
-1. **TProducerConsumerThreadPool**
-   - Custom instance creation
-   - Control over thread count and queue size
-   - Fixed-size work queue (default 1024 items)
-   - Thread-safe operation
-   - Built-in backpressure handling
-   - Debug logging enabled by default
-   - Error handling support
+For simpler use cases see `ThreadPool.Simple`.
 
-### Core Functions
+---
 
-#### Constructor
+## Constructor
+
 ```pascal
 constructor Create(AThreadCount: Integer = 0; AQueueSize: Integer = 1024);
 ```
-Creates a new thread pool instance.
-- `AThreadCount`: Number of worker threads. If 0, uses CPU count
-- `AQueueSize`: Size of work queue. Defaults to 1024 items
 
-#### Queue Operations
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `AThreadCount` | `0` (uses CPU count) | Worker threads. Clamped: min 4, max 2× `ProcessorCount` |
+| `AQueueSize` | `1024` | Circular queue capacity in work items |
+
 ```pascal
-// Queue a simple procedure
-Pool.Queue(@MyProcedure);
+// Default: CPU-count threads, 1024-item queue
+Pool := TProducerConsumerThreadPool.Create;
 
-// Queue a method of an object
-Pool.Queue(@MyObject.MyMethod);
-
-// Queue a procedure with an index
-Pool.Queue(@MyIndexedProcedure, 42);
-
-// Queue a method with an index
-Pool.Queue(@MyObject.MyIndexedMethod, 42);
+// Custom: 4 threads, 512-item queue
+Pool := TProducerConsumerThreadPool.Create(4, 512);
 ```
 
-#### Error Handling
+---
+
+## Queue Methods
+
+All four overloads are thread-safe. Each call may block briefly if the queue is
+near capacity (adaptive backpressure delays apply). After the maximum retry
+attempts are exhausted, `EQueueFullException` is raised.
+
+```pascal
+procedure Queue(AProcedure: TThreadProcedure);
+procedure Queue(AMethod: TThreadMethod);
+procedure Queue(AProcedure: TThreadProcedureIndex; AIndex: Integer);
+procedure Queue(AMethod: TThreadMethodIndex; AIndex: Integer);
+```
+
+```pascal
+Pool.Queue(@MyProcedure);            // plain procedure
+Pool.Queue(@MyObject.MyMethod);      // object method
+Pool.Queue(@MyIndexedProc, 42);      // indexed procedure
+Pool.Queue(@MyObject.MyMethod, 42);  // indexed method
+```
+
+### Task type signatures (from `ThreadPool.Types`)
+
+```pascal
+TThreadProcedure      = procedure;
+TThreadMethod         = procedure of object;
+TThreadProcedureIndex = procedure(index: Integer);
+TThreadMethodIndex    = procedure(index: Integer) of object;
+```
+
+---
+
+## WaitForAll
+
+Blocks until every queued task has finished executing.
+
+```pascal
+Pool.WaitForAll;
+```
+
+Always call before freeing the pool or any objects whose methods were queued.
+
+---
+
+## Error Handling
+
+Two distinct error paths exist — handle both:
+
+### 1. Queue-full errors (raised by `Queue`)
+
+`EQueueFullException` is raised synchronously on the calling thread when the
+queue stays full after all retry attempts. Catch it **around each `Queue` call**,
+not around `WaitForAll`.
+
+```pascal
+try
+  Pool.Queue(@MyProcedure);
+except
+  on E: EQueueFullException do
+  begin
+    // Queue is saturated. Options:
+    // - wait and retry: Pool.WaitForAll; Pool.Queue(@MyProcedure);
+    // - log and skip
+    WriteLn('Queue full: ', E.Message);
+  end;
+end;
+```
+
+The exception message format is:
+
+```text
+Queue is full after N attempts (Capacity: M)
+```
+
+Always catch by **type** (`EQueueFullException`), not by message string.
+
+### 2. Worker execution errors (read from `LastError`)
+
+Exceptions that occur *inside* a task are caught by the worker thread and stored
+in `LastError`. Check after `WaitForAll`.
+
+```pascal
+Pool.WaitForAll;
+
+if Pool.LastError <> '' then
+begin
+  // LastError holds the raw message of the most recent worker exception.
+  // Earlier failures are overwritten — only the last one is available.
+  WriteLn('Task error: ', Pool.LastError);
+  Pool.ClearLastError;  // reset before reuse
+end;
+```
+
+### Full pattern
+
 ```pascal
 var
   Pool: TProducerConsumerThreadPool;
@@ -47,166 +133,173 @@ begin
   try
     try
       Pool.Queue(@RiskyOperation);
-      Pool.WaitForAll;
     except
       on E: EQueueFullException do
-      begin
-        // Handle queue full condition
-        WriteLn('Queue is full: ', E.Message);
-      end;
+        WriteLn('Queue full: ', E.Message);
     end;
-    
-    // Check for execution errors after completion
+
+    Pool.WaitForAll;
+
     if Pool.LastError <> '' then
-      WriteLn('Error occurred: ', Pool.LastError);
+      WriteLn('Task failed: ', Pool.LastError);
   finally
     Pool.Free;
   end;
 end;
 ```
 
-#### Synchronization
+---
+
+## Properties and Methods
+
 ```pascal
-// Wait for all queued tasks to complete
-Pool.WaitForAll;
+property ThreadCount: Integer;        // read-only; number of worker threads
+property LastError: string;           // read-only; last worker exception message
+property WorkQueue: TThreadSafeQueue; // access to queue for monitoring/config
+
+procedure WaitForAll;
+procedure ClearLastError;
 ```
 
-### 📋 API Reference
+---
 
-#### Constructor
-```pascal
-constructor Create(AThreadCount: Integer = 0; AQueueSize: Integer = 1024);
-```
-Creates a new thread pool instance.
-- `AThreadCount`: Number of worker threads. If 0, uses CPU count
-- `AQueueSize`: Size of work queue. Defaults to 1024 items
+## Backpressure Configuration
 
-#### Queue Methods
-```pascal
-procedure Queue(AProcedure: TThreadProcedure);
-procedure Queue(AMethod: TThreadMethod);
-procedure Queue(AProcedure: TThreadProcedureIndex; AIndex: Integer);
-procedure Queue(AMethod: TThreadMethodIndex; AIndex: Integer);
-```
-All Queue methods:
-- Are thread-safe
-- Support backpressure handling
-- Raise EQueueFullException if queue is full after retries
-- Support different task types
+When the queue load factor exceeds a threshold, `Queue` introduces a delay before
+each retry attempt. This slows the producer instead of failing immediately.
 
-#### Control Methods
-```pascal
-procedure WaitForAll;    // Wait for completion
-procedure ClearLastError;  // Clear error state
-```
-
-#### Properties
-```pascal
-property ThreadCount: Integer;  // Number of worker threads
-property LastError: string;     // Last error message
-```
-
-#### Backpressure Configuration
 ```pascal
 type
   TBackpressureConfig = record
-    LowLoadThreshold: Double;    // Default: 0.5 (50%)
-    MediumLoadThreshold: Double; // Default: 0.7 (70%)
-    HighLoadThreshold: Double;   // Default: 0.9 (90%)
-    LowLoadDelay: Integer;       // Default: 10ms
-    MediumLoadDelay: Integer;    // Default: 50ms
-    HighLoadDelay: Integer;      // Default: 100ms
-    MaxAttempts: Integer;        // Default: 5 attempts
+    LowLoadThreshold:    Double;   // Default: 0.5  — delay starts at 50% capacity
+    MediumLoadThreshold: Double;   // Default: 0.7  — medium delay at 70%
+    HighLoadThreshold:   Double;   // Default: 0.9  — max delay at 90%
+    LowLoadDelay:        Integer;  // Default: 10 ms
+    MediumLoadDelay:     Integer;  // Default: 50 ms
+    HighLoadDelay:       Integer;  // Default: 100 ms
+    MaxAttempts:         Integer;  // Default: 5 — raises EQueueFullException after this
   end;
 ```
 
-### 🚨 Important Notes
-
-1. **Thread Safety**
-   - All operations are thread-safe
-   - Queue has fixed capacity (1024 items, configurable)
-   - Built-in retry mechanism (5 attempts, configurable)
-   - Error handling is thread-safe
-
-2. **Debug Logging**
-   - Enabled by default (DEBUG_LOG = True)
-   - Includes thread IDs and timestamps
-   - Logs queue operations and errors
-   - Helps in troubleshooting
-
-3. **Object Lifetime**
-   - Keep objects alive until their methods complete
-   - Wait for tasks before freeing objects
-   - Use try-finally blocks for cleanup
-
-4. **Best Practices**
-   - Monitor queue capacity
-   - Handle EQueueFullException
-   - Clear errors before reuse
-   - Always wait for completion
-
-### ⚠️ Common Pitfalls
+Read and write the config through `WorkQueue.BackpressureConfig`:
 
 ```pascal
-// DON'T DO THIS - Queue might be full
-try
-  for i := 1 to 2000 do  // Too many items!
-    Pool.Queue(@MyProc);
-except
-  // Queue full exception
-end;
-
-// DO THIS INSTEAD
-for i := 1 to 2000 do
+var
+  Config: TBackpressureConfig;
 begin
-  try
-    Pool.Queue(@MyProc);
-  except
-    on E: Exception do
-      if E.Message = 'Queue is full' then
-      begin
-        Pool.WaitForAll;  // Wait for queue to clear
-        Pool.Queue(@MyProc);  // Try again
-      end;
-  end;
-end;
-
-// DON'T DO THIS - Object freed too early
-MyObject := TMyClass.Create;
-Pool.Queue(@MyObject.MyMethod);
-MyObject.Free;  // Wrong!
-
-// DO THIS INSTEAD
-MyObject := TMyClass.Create;
-try
-  Pool.Queue(@MyObject.MyMethod);
-  Pool.WaitForAll;  // Wait for completion
-finally
-  MyObject.Free;  // Safe now
+  Config := Pool.WorkQueue.BackpressureConfig;
+  Config.MaxAttempts   := 3;
+  Config.HighLoadDelay := 200;
+  Pool.WorkQueue.BackpressureConfig := Config;
 end;
 ```
 
-### 🔧 Advanced Usage
+---
 
-#### Queue Management
+## Debug Logging
+
+The constant `DEBUG_LOG` at the top of the unit controls verbose output:
+
+```pascal
+const
+  DEBUG_LOG = True;  // set to False to silence all debug output
+```
+
+When enabled, each queue operation and worker event is logged to stdout with a
+timestamp and thread ID. Disable for production use.
+
+---
+
+## Thread Count Rules
+
+| Condition | Result |
+| --- | --- |
+| `AThreadCount <= 0` | Uses `TThread.ProcessorCount` |
+| `AThreadCount < 4` | Raised to 4 (minimum enforced) |
+| `AThreadCount > 2 × ProcessorCount` | Clamped to `2 × ProcessorCount` |
+
+Thread count is fixed after construction.
+
+---
+
+## Common Pitfalls
+
+### Catching EQueueFullException by message string
+
+```pascal
+// WRONG — the message includes dynamic content and will never match literally
+on E: Exception do
+  if E.Message = 'Queue is full' then ...
+
+// CORRECT — catch by exception type
+on E: EQueueFullException do ...
+```
+
+### Freeing an object before WaitForAll
+
+```pascal
+// WRONG — worker thread may still be calling MyObject.MyMethod
+Pool.Queue(@MyObject.MyMethod);
+MyObject.Free;
+
+// CORRECT
+try
+  Pool.Queue(@MyObject.MyMethod);
+  Pool.WaitForAll;
+finally
+  MyObject.Free;
+end;
+```
+
+### Placing WaitForAll inside the EQueueFullException handler
+
+```pascal
+// WRONG — if Queue raises, WaitForAll is never reached, pool is freed while busy
+try
+  Pool.Queue(@MyProc);
+  Pool.WaitForAll;   // skipped on exception
+except
+  on E: EQueueFullException do ...
+end;
+Pool.Free;
+
+// CORRECT — separate concerns
+try
+  Pool.Queue(@MyProc);
+except
+  on E: EQueueFullException do
+    WriteLn('Queue full: ', E.Message);
+end;
+Pool.WaitForAll;  // always reached
+Pool.Free;
+```
+
+---
+
+## Advanced: Queue Management
+
+Queue multiple items and handle overflow per-item:
+
 ```pascal
 var
   Pool: TProducerConsumerThreadPool;
+  i: Integer;
 begin
-  // Create pool with specific thread count
-  Pool := TProducerConsumerThreadPool.Create(4);
+  Pool := TProducerConsumerThreadPool.Create(4, 512);
   try
-    // Queue until full
-    while True do
-    try
-      Pool.Queue(@MyProc);
-    except
-      on E: Exception do
-        if E.Message = 'Queue is full' then
-          Break;
+    for i := 1 to 2000 do
+    begin
+      try
+        Pool.Queue(@MyProc);
+      except
+        on E: EQueueFullException do
+        begin
+          Pool.WaitForAll;   // let the queue drain
+          Pool.Queue(@MyProc);  // retry
+        end;
+      end;
     end;
-    
-    // Process queue
+
     Pool.WaitForAll;
   finally
     Pool.Free;
@@ -214,82 +307,12 @@ begin
 end;
 ```
 
-### 📝 Type Definitions
+---
 
-```pascal
-type
-  TThreadProcedure = procedure;
-  TThreadMethod = procedure of object;
-  TThreadProcedureIndex = procedure(Index: Integer);
-  TThreadMethodIndex = procedure(Index: Integer) of object;
-```
+## Limitations
 
-### 🔍 Thread Management
-
-1. **Thread Count Rules**
-   - Default: Uses `ProcessorCount` when thread count ≤ 0
-   - Minimum: 4 threads enforced
-   - Maximum: 2× `ProcessorCount`
-   - Thread creation: All threads created at startup
-
-2. **Performance Tuning**
-   - Worker threads sleep 100ms when idle
-   - Fixed queue size affects memory usage
-   - Consider queue capacity when designing tasks
-   - Balance thread count with system resources
-
-### 🛡️ Thread Safety Guarantees
-
-1. **Queue Operations**
-   - Thread-safe work item queueing
-   - Protected work item count
-   - Safe error state management
-   - Synchronized completion tracking
-
-2. **Resource Management**
-   - Safe worker thread termination
-   - Protected queue access
-   - Thread-safe error handling
-   - Proper cleanup in destructor
-
-### ⚡ Performance Tips
-
-1. **Queue Management**
-   - Monitor queue capacity (1024 items, configurable)
-   - Handle queue full conditions
-   - Consider batching small tasks
-   - Watch for queue saturation
-
-2. **Task Design**
-   - Keep tasks reasonably sized
-   - Avoid very short tasks
-   - Handle long-running tasks appropriately
-   - Consider task dependencies
-
-### 🚫 Limitations
-
-1. **Queue Constraints**
-   - Fixed capacity (1024 items by default, configurable)
-   - No dynamic resizing
-   - Blocking on queue full
-   - No priority queueing
-
-2. **Error Handling**
-   - Single error storage
-   - Last error overwrites previous
-   - No error event mechanism
-   - No error queueing
-
-### 💡 Usage Recommendations
-
-1. **Optimal Use Cases**
-   - Batch processing tasks
-   - Parallel computations
-   - I/O operations
-   - CPU-intensive work
-
-2. **Less Suitable For**
-   - Very short tasks (overhead)
-   - Real-time operations
-   - UI thread work
-   - Critical timing requirements
+- Fixed queue capacity — no dynamic resizing
+- Only the most recent worker exception is stored in `LastError`
+- No task priority or cancellation support
+- No dynamic thread scaling after construction
+- Not suitable for real-time or UI-thread work

--- a/docs/ThreadPool.ProducerConsumer-Technical.md
+++ b/docs/ThreadPool.ProducerConsumer-Technical.md
@@ -1,62 +1,19 @@
-# ThreadPool.ProducerConsumer Technical
+# ThreadPool.ProducerConsumer — Technical Documentation
 
 ## Overview
-The `ThreadPool.ProducerConsumer` unit implements a thread pool using the producer-consumer pattern with advanced backpressure handling. It provides a thread-safe queue for work items and manages a pool of worker threads that process these items.
 
-### Key Features
+`ThreadPool.ProducerConsumer` implements a thread pool using the
+producer-consumer pattern. Tasks are placed into a fixed-size circular buffer by
+the caller (producer) and removed for execution by worker threads (consumers).
+When the buffer fills faster than workers can drain it, adaptive backpressure
+slows the producer before raising `EQueueFullException`.
 
-1. **Backpressure Management**
-   - Configurable load thresholds and delays
-   - Default thresholds:
-     - Low Load: 50% (0.5)
-     - Medium Load: 70% (0.7)
-     - High Load: 90% (0.9)
-   - Default delays:
-     - Low Load: 10ms
-     - Medium Load: 50ms
-     - High Load: 100ms
-   - Maximum retry attempts: 5
-
-2. **Debug Logging**
-   - Enabled by default (DEBUG_LOG = True)
-   - Includes timestamps and thread IDs
-   - Logs queue operations and thread activities
-   - Helps in monitoring and debugging
-
-3. **Enhanced Error Handling**
-   - New `EQueueFullException` for queue saturation
-   - Detailed error messages with queue state
-   - Thread-safe error reporting
-   - Proper exception propagation
-
-### Queue Management Strategy
-
-The implementation uses a fixed-size circular buffer with backpressure:
-- **Bounded Queue:** Fixed capacity of 1024 items prevents memory exhaustion (configurable)
-- **Load Monitoring:** Continuous tracking of queue load factor
-- **Adaptive Delays:** Response times adjust based on queue load
-- **Fail-Fast Policy:** Throws EQueueFullException after max attempts
-
-### Producer-Consumer Thread Pool Details
-
-The **Producer-Consumer Thread Pool** utilizes a fixed-size circular buffer combined with backpressure and retry mechanisms:
-
-- **Fixed-Size Circular Buffer**
-  - **Capacity:** The task queue is 1024 items (by default, configurable) to ensure predictable memory usage.
-  - **Circular Nature:** Efficiently reuses buffer space without the need for dynamic resizing.
-
-- **Built-in Retry Mechanism**
-  - **Automatic Retries:** When queue is full, the system will automatically retry up to 5 times (configurable)
-  - **Backpressure Delays:** Each retry attempt includes adaptive delays based on queue load
-  - **Exception Handling:** Throws EQueueFullException after maximum attempts are exhausted
-
-> [!WARNING]
-> 
-> While the system includes automatic retry mechanisms, it's recommended that users implement their own error handling strategies for scenarios where the queue remains full after all retry attempts.
+---
 
 ## Architecture
 
 ### Class Structure
+
 ```mermaid
 classDiagram
     class TThreadPoolBase {
@@ -70,7 +27,7 @@ classDiagram
         +GetLastError()
         +ClearLastError()
     }
-    
+
     class TProducerConsumerThreadPool {
         -FThreads: TThreadList
         -FWorkQueue: TThreadSafeQueue
@@ -79,16 +36,17 @@ classDiagram
         -FErrorLock: TCriticalSection
         -FWorkItemLock: TCriticalSection
         -FLocalThreadCount: Integer
-        +Create(threadCount: Integer)
+        +Create(threadCount, queueSize: Integer)
         +Queue(procedure)
         +Queue(method)
         +Queue(procedureIndex, index)
         +Queue(methodIndex, index)
         +WaitForAll()
-        +GetLastError()
-        +ClearLastError()
+        +WorkQueue: TThreadSafeQueue
+        +ThreadCount: Integer
+        +LastError: string
     }
-    
+
     class TThreadSafeQueue {
         -FItems: array of IWorkItem
         -FHead: Integer
@@ -96,13 +54,16 @@ classDiagram
         -FCount: Integer
         -FCapacity: Integer
         -FLock: TCriticalSection
+        -FBackpressureConfig: TBackpressureConfig
         +Create(capacity: Integer)
         +TryEnqueue(item: IWorkItem): Boolean
         +TryDequeue(out item: IWorkItem): Boolean
         +GetCount(): Integer
+        +LoadFactor: Double
+        +BackpressureConfig: TBackpressureConfig
         +Clear()
     }
-    
+
     class TProducerConsumerWorkerThread {
         -FThreadPool: TObject
         +Create(threadPool: TObject)
@@ -115,31 +76,35 @@ classDiagram
 ```
 
 ### Component Interaction
+
 ```mermaid
 sequenceDiagram
     participant App as Application
-    participant Pool as ThreadPool
-    participant Queue as WorkQueue
-    participant Worker as WorkerThread
-    
+    participant Pool as TProducerConsumerThreadPool
+    participant Queue as TThreadSafeQueue
+    participant Worker as TProducerConsumerWorkerThread
+
     App->>Pool: Queue(Task)
-    Pool->>Queue: TryEnqueue
-    alt Queue Full After Max Attempts
-        Queue-->>App: Raise EQueueFullException
-    else Queue Space Available
-        Queue-->>Pool: true
-        Pool-->>App: Return
+    Pool->>Pool: Increment FWorkItemCount
+    Pool->>Queue: TryEnqueue(WorkItem)
+    alt Queue full after MaxAttempts
+        Queue-->>App: raise EQueueFullException
+        Pool->>Pool: Decrement FWorkItemCount
+    else Space available
+        Queue-->>Pool: True
+        Pool-->>App: return
         Worker->>Queue: TryDequeue
-        Queue-->>Worker: Work Item
-        Worker->>Worker: Execute Task
-        Worker->>Pool: Update Count
-        opt Last Task
-            Pool->>App: Signal Completion
+        Queue-->>Worker: WorkItem
+        Worker->>Worker: WorkItem.Execute
+        Worker->>Pool: Decrement FWorkItemCount
+        opt FWorkItemCount = 0
+            Pool->>App: FCompletionEvent.SetEvent
         end
     end
 ```
 
 ### Thread Pool States
+
 ```mermaid
 stateDiagram-v2
     [*] --> Created: Create()
@@ -155,257 +120,173 @@ stateDiagram-v2
 ```
 
 ### Work Item Flow
+
 ```mermaid
 flowchart LR
-    A[Task] -->|Create| B[Work Item]
-    B -->|Queue| C[Thread Pool]
-    C -->|Enqueue| D[Work Queue]
-    D -->|Dequeue| E[Worker Thread]
-    E -->|Execute| F[Complete]
-    E -->|Error| G[Error State]
-    G -->|Report| C
+    A[Task] -->|Create| B[TProducerConsumerWorkItem]
+    B -->|TryEnqueue| C[TThreadSafeQueue]
+    C -->|TryDequeue| D[TProducerConsumerWorkerThread]
+    D -->|Execute| E[Complete]
+    D -->|Exception| F[SetLastError]
+    F --> G[Pool.LastError]
 ```
+
+---
 
 ## Key Components
 
 ### TProducerConsumerThreadPool
-- Main thread pool implementation
-- Manages worker threads and work queue
-- Handles task queueing and completion tracking
-- Thread count defaults to CPU count if not specified
-- Thread-safe operation using critical sections
+
+The main class. It:
+
+- Creates and starts all worker threads at construction time
+- Wraps each `Queue` call into a `TProducerConsumerWorkItem` and passes it to `TThreadSafeQueue.TryEnqueue`
+- Tracks the number of in-flight work items (`FWorkItemCount`) under `FWorkItemLock`
+- Signals `FCompletionEvent` when `FWorkItemCount` reaches zero (satisfying `WaitForAll`)
+- Stores the most recent worker exception message in `FLastError` under `FErrorLock`
 
 ### TThreadSafeQueue
-- Thread-safe circular queue implementation
-- Fixed capacity (1024 items by default, configurable)
-- Provides TryEnqueue and TryDequeue operations
-- Handles queue full/empty conditions
-- Uses critical section for thread safety
-- Implements backpressure mechanism
-- Monitors queue load factor
+
+A thread-safe circular buffer. Key properties:
+
+- **Capacity** is fixed at construction — no dynamic resizing
+- **Head/tail pointers** wrap around modulo capacity: O(1) enqueue and dequeue
+- `LoadFactor` = `FCount / FCapacity` — used by backpressure logic
+- All operations are protected by a single `TCriticalSection` (`FLock`)
 
 ### TProducerConsumerWorkerThread
-- Worker thread implementation
-- Continuously processes items from queue
-- Handles work item execution and error reporting
-- Sleeps when queue is empty (100ms intervals)
-- Created suspended, started explicitly
 
-## Thread Safety
-- Uses critical sections for queue operations (FLock)
-- Uses critical sections for work item count (FWorkItemLock)
-- Uses critical sections for error handling (FErrorLock)
-- Uses event object for completion signaling (FCompletionEvent)
-- Thread-safe backpressure application
+Each worker:
 
-## Error Handling
-- Queue full conditions trigger retry mechanism
-- Maximum retry attempts (default: 5)
-- EQueueFullException raised after max retries
-- Work item execution errors are captured and stored
-- Thread termination is handled gracefully
-- Last error accessible via LastError property
+- Loops calling `TryDequeue`; executes the work item if one is available
+- Calls `Sleep(100)` when the queue is empty to avoid busy-waiting
+- On exception inside `Execute`, stores the message in `Pool.FLastError` and
+  decrements the work item counter normally (pool keeps running)
+- Exits the loop when `Terminated` is set during pool destruction
 
-## Performance Considerations
-- Fixed queue size (1024 items by default, configurable)
-- Adaptive delays based on queue load
-- Worker threads sleep 100ms when queue empty
-- Thread count optimized for CPU count by default
-- Thread-safe operations with minimal locking
-- Backpressure helps prevent system overload
+---
 
-## Thread Management Details
+## Backpressure
 
-### Thread Creation and Startup
-- Threads created in suspended state
-- Started explicitly after creation
-- Thread count rules:
-  - Minimum: 4 threads
-  - Maximum: 2× `ProcessorCount`
-  - Default: `ProcessorCount` when not specified
-- No dynamic thread creation/destruction
+Before each enqueue attempt, `ApplyBackpressure` reads `LoadFactor` and sleeps
+for a configurable duration:
 
-### Thread Termination
-- Graceful shutdown via Terminate flag
-- Waits for threads to finish current task
-- Proper cleanup of thread resources
-- Thread-safe removal from thread list
+| Load factor | Default delay |
+| --- | --- |
+| ≥ 50% (`LowLoadThreshold`) | 10 ms |
+| ≥ 70% (`MediumLoadThreshold`) | 50 ms |
+| ≥ 90% (`HighLoadThreshold`) | 100 ms |
 
-### Thread State Management
+After `MaxAttempts` (default 5) failures, `EQueueFullException` is raised.
+
+Configure via `Pool.WorkQueue.BackpressureConfig`:
+
 ```pascal
-procedure TProducerConsumerWorkerThread.Execute;
+var
+  Config: TBackpressureConfig;
 begin
-  while not Terminated do
-  begin
-    if TryGetWorkItem then
-      ProcessWorkItem
-    else
-      Sleep(100);  // Prevent busy waiting
-  end;
+  Config := Pool.WorkQueue.BackpressureConfig;
+  Config.MaxAttempts   := 3;
+  Config.HighLoadDelay := 200;
+  Pool.WorkQueue.BackpressureConfig := Config;
 end;
 ```
 
-## Exception Handling Implementation
+---
 
-### Worker Thread Exceptions
-```pascal
-try
-  WorkItem.Execute;
-except
-  on E: Exception do
-  begin
-    Pool.FErrorLock.Enter;
-    try
-      Pool.SetLastError(E.Message);
-    finally
-      Pool.FErrorLock.Leave;
-    end;
-  end;
-end;
-```
+## Implementation Details
 
-### Queue Operation Exceptions
-- Queue full detection via TryEnqueue
-- Exception propagation to caller
-- Work item count adjustment
-- Completion event management
-
-### Error State Management
-- Thread-safe error storage
-- Last error overwrite policy
-- Error clearing mechanism
-- Error retrieval synchronization
-
-## Performance Details
-
-### Queue Implementation Strategy
-
-#### Current Approach
-The implementation uses a fixed-size circular buffer with backpressure:
-- **Bounded Queue:** Fixed capacity of 1024 items (by default, configurable) prevents memory exhaustion
-- **Thread Safety:** All operations protected by FLock critical section
-- **Backpressure Policy:** Adaptive delays based on queue load factor
-
+### TryEnqueue — full implementation
 
 ```pascal
 function TThreadSafeQueue.TryEnqueue(AItem: IWorkItem): boolean;
+var
+  Attempts: Integer;
 begin
-  Result := False;
-  FLock.Enter;
-  try
-    if FCount < FCapacity then
-    begin
-      FItems[FTail] := AItem;
-      FTail := (FTail + 1) mod FCapacity;
-      Inc(FCount);
-      Result := True;
+  if AItem = nil then Exit(False);
+
+  Attempts := 0;
+  while Attempts < FBackpressureConfig.MaxAttempts do
+  begin
+    ApplyBackpressure;  // adaptive delay based on current LoadFactor
+
+    FLock.Enter;
+    try
+      if FCount < FCapacity then
+      begin
+        FItems[FTail] := AItem;
+        FTail := (FTail + 1) mod FCapacity;
+        Inc(FCount);
+        FLastEnqueueTime := Now;
+        Exit(True);  // success
+      end;
+    finally
+      FLock.Leave;
     end;
-  finally
-    FLock.Leave;
+
+    Inc(Attempts);
+    if Attempts < FBackpressureConfig.MaxAttempts then
+      Sleep(10);
   end;
+
+  // All attempts exhausted
+  raise EQueueFullException.Create(Format(
+    'Queue is full after %d attempts (Capacity: %d)',
+    [FBackpressureConfig.MaxAttempts, FCapacity]));
 end;
 ```
 
+### Worker Execute loop
 
-### Benefits of Current Strategy
-1. **Memory Safety**
-   - Predictable memory usage
-   - No risk of unbounded growth
-   - Protected against memory exhaustion
-
-2. **Performance**
-   - O(1) enqueue/dequeue operations
-   - Minimal lock contention
-   - No memory allocation during operation
-   - Quick failure detection
-
-3. **Reliability**
-   - Clear failure semantics
-   - Thread-safe operations
-   - No hidden blocking
-   - Predictable behavior under load
-
-### Critical Section Usage
 ```pascal
-type
-  TThreadSafeQueue = class
-  private
-    FLock: TCriticalSection;
-    // ...
-  end;
-
-procedure TThreadSafeQueue.TryEnqueue;
+procedure TProducerConsumerWorkerThread.Execute;
+var
+  Pool: TProducerConsumerThreadPool;
+  WorkItem: IWorkItem;
 begin
-  FLock.Enter;
-  try
-    // Minimal critical section scope
-  finally
-    FLock.Leave;
+  Pool := TProducerConsumerThreadPool(FThreadPool);
+
+  while not Terminated do
+  begin
+    if Pool.FWorkQueue.TryDequeue(WorkItem) then
+    begin
+      try
+        WorkItem.Execute;
+      except
+        on E: Exception do
+        begin
+          Pool.FErrorLock.Enter;
+          try
+            Pool.SetLastError(E.Message);
+          finally
+            Pool.FErrorLock.Leave;
+          end;
+        end;
+      end;
+
+      // Decrement counter; signal WaitForAll when last item finishes
+      Pool.FWorkItemLock.Enter;
+      try
+        Dec(Pool.FWorkItemCount);
+        if Pool.FWorkItemCount = 0 then
+          Pool.FCompletionEvent.SetEvent;
+      finally
+        Pool.FWorkItemLock.Leave;
+      end;
+    end
+    else
+      Sleep(100);  // queue empty — avoid busy-waiting
   end;
 end;
 ```
 
-### Memory Management
-- Pre-allocated queue buffer
-- No dynamic resizing
-- Work item reference counting
-- Proper interface cleanup
+### Destructor / cleanup sequence
 
-### Thread Synchronization
-- Event-based completion signaling
-- Sleep-based idle management
-- Multiple critical sections for different concerns
-- Minimal lock scope
-
-## Implementation Limitations
-
-### Queue Constraints
-1. **Fixed Capacity**
-   - 1024 items maximum (by default, configurable)
-   - No dynamic growth
-   - Blocking on full
-   - No priority support
-
-2. **Performance Impact**
-   - Memory pre-allocation
-   - Potential queue saturation
-   - Sleep delay overhead
-   - Lock contention possible
-
-### Thread Management Limitations
-1. **Static Threading**
-   - Fixed thread count
-   - No dynamic scaling
-   - No thread pool resizing
-   - No thread priority control
-
-2. **Resource Usage**
-   - Memory for queue buffer
-   - Thread stack allocation
-   - Critical section overhead
-   - Event object overhead
-
-### Error Handling Limitations
-1. **Error Storage**
-   - Single error message
-   - Last error overwrites
-   - No error history
-   - No error categorization
-
-2. **Exception Management**
-   - Limited error propagation
-   - No error event system
-   - No error recovery mechanism
-   - No error filtering
-
-## Resource Management
-
-### Cleanup Sequence
 ```pascal
 destructor TProducerConsumerThreadPool.Destroy;
 begin
-  ClearThreads;        // Stop and free threads
-  FWorkQueue.Free;     // Free queue and items
+  ClearThreads;          // sets Terminated, waits for all threads, frees them
+  FWorkQueue.Free;
   FCompletionEvent.Free;
   FErrorLock.Free;
   FWorkItemLock.Free;
@@ -414,15 +295,35 @@ begin
 end;
 ```
 
-### Resource Lifetime
-- Thread termination before cleanup
-- Work item completion handling
-- Critical section disposal
-- Event object cleanup
+---
 
-### Memory Considerations
-- Queue buffer allocation
-- Thread stack allocation
-- Work item interface references
-- Synchronization object overhead
+## Thread Safety Summary
 
+| Object | Protects |
+| --- | --- |
+| `FLock` (in TThreadSafeQueue) | Queue head/tail/count during enqueue and dequeue |
+| `FWorkItemLock` | `FWorkItemCount` and `FCompletionEvent` |
+| `FErrorLock` | `FLastError` writes from worker threads |
+| `FCompletionEvent` | Signals `WaitForAll` when all items are done |
+
+---
+
+## Performance Considerations
+
+- **O(1)** enqueue and dequeue — circular buffer, no shifting
+- Backpressure delays add latency on the producer side when the queue is busy;
+  tune `MaxAttempts` and delay values for your workload
+- Workers sleep **100 ms** when the queue is empty — acceptable for batch
+  workloads, but not suitable for latency-sensitive tasks
+- `DEBUG_LOG = True` by default; set it to `False` in production to eliminate
+  the overhead of timestamped console output
+
+---
+
+## Limitations
+
+- Fixed queue capacity — no dynamic resizing
+- Only the most recent worker exception is stored (`LastError`)
+- No task priority, ordering guarantees, or cancellation
+- Thread count is fixed after construction — no dynamic scaling
+- Debug logging writes to stdout; there is no log-level or handler API

--- a/docs/ThreadPool.Simple-API.md
+++ b/docs/ThreadPool.Simple-API.md
@@ -1,80 +1,149 @@
-## 📚 API Documentation
+# ThreadPool.Simple API Documentation
 
-### Thread Pool Types
+## Thread Pool Types
 
-1. **GlobalThreadPool**
-   - Singleton instance for simple usage
-   - Automatically initialized
-   - Suitable for most applications
-   - Uses default thread count
+### GlobalThreadPool
 
-2. **TSimpleThreadPool**
-   - Custom instance creation
-   - Control over thread count
-   - Multiple pools possible
-   - More control over lifetime
+A ready-to-use singleton instance declared in the `ThreadPool.Simple` unit.
 
-
-### Core Functions
-
-#### Queue Operations
+- Created automatically at program startup — do **not** call `GlobalThreadPool.Free`
+- Uses the default thread count (`ProcessorCount`, minimum 4)
+- Suitable for most applications
 
 ```pascal
-// Queue a simple procedure
+uses ThreadPool.Simple;
+
 GlobalThreadPool.Queue(@MyProcedure);
-
-// Queue a method of an object
-GlobalThreadPool.Queue(@MyObject.MyMethod);
-
-// Queue a procedure with an index
-GlobalThreadPool.Queue(@MyIndexedProcedure, 42);
-
-// Queue a method with an index
-GlobalThreadPool.Queue(@MyObject.MyIndexedMethod, 42);
+GlobalThreadPool.WaitForAll;
 ```
 
-#### Error Handling
+### TSimpleThreadPool
 
-See `Test16_ExceptionHandling` and `Test18_ExceptionMessage`.
+A manually managed pool for when you need explicit control over thread count or lifetime.
+
+- Create with `TSimpleThreadPool.Create(AThreadCount)`
+- Thread count is clamped: minimum 4, maximum 2× `ProcessorCount`
+- Multiple independent pools can coexist
+- Must be freed by the caller
 
 ```pascal
+uses ThreadPool.Simple;
+
 var
-  Pool: TSimpleThreadPool; 
+  Pool: TSimpleThreadPool;
 begin
-  Pool := TSimpleThreadPool.Create;
+  Pool := TSimpleThreadPool.Create(4);
   try
-    Pool.Queue(@RiskyProcedure);
+    Pool.Queue(@MyProcedure);
     Pool.WaitForAll;
-    
-    // Check for errors after completion
-    if Pool.LastError <> '' then
-    begin
-      WriteLn('Error occurred: ', Pool.LastError);
-      // Error messages include thread ID and exception message
-      // Example: "[Thread 1234] Test exception message"
-    end;
-    
-    // Clear error state if needed for pool reuse
-    Pool.ClearLastError;
   finally
     Pool.Free;
   end;
 end;
 ```
 
-#### Synchronization
+---
+
+## Queue Overloads
+
+All four `Queue` overloads are thread-safe and can be called from any thread.
+
 ```pascal
-// Wait for all queued tasks to complete
+// 1. Plain procedure — no shared state needed
+GlobalThreadPool.Queue(@MyProcedure);
+
+// 2. Object method — task needs access to object fields
+GlobalThreadPool.Queue(@MyObject.MyMethod);
+
+// 3. Indexed procedure — loop parallelism
+GlobalThreadPool.Queue(@MyIndexedProcedure, 42);
+
+// 4. Indexed method — loop parallelism + object state
+GlobalThreadPool.Queue(@MyObject.MyIndexedMethod, 42);
+```
+
+### Type signatures (from `ThreadPool.Types`)
+
+```pascal
+TThreadProcedure      = procedure;
+TThreadMethod         = procedure of object;
+TThreadProcedureIndex = procedure(index: Integer);
+TThreadMethodIndex    = procedure(index: Integer) of object;
+```
+
+---
+
+## WaitForAll
+
+Blocks the calling thread until every queued task has finished executing.
+
+```pascal
 GlobalThreadPool.WaitForAll;
 ```
 
-### Usage Examples
+Always call `WaitForAll` before:
 
-#### 1. Simple Procedure
+- Reading results written by worker tasks
+- Freeing objects whose methods were queued
+- Calling `LastError`
+
+---
+
+## Error Handling
+
+Worker thread exceptions are caught automatically and stored in `LastError`. The pool
+continues processing remaining tasks after an exception.
+
+```pascal
+var
+  Pool: TSimpleThreadPool;
+begin
+  Pool := TSimpleThreadPool.Create(4);
+  try
+    Pool.Queue(@RiskyProcedure);
+    Pool.WaitForAll;
+
+    if Pool.LastError <> '' then
+    begin
+      // LastError holds the raw exception message of the most recent failure.
+      // If multiple tasks fail, only the last exception is stored.
+      WriteLn('Error: ', Pool.LastError);
+      Pool.ClearLastError;  // Reset before reusing the pool
+    end;
+  finally
+    Pool.Free;
+  end;
+end;
+```
+
+### Properties
+
+```pascal
+property LastError: string;   // Raw message of the most recent worker exception
+property ThreadCount: Integer; // Number of worker threads (read-only)
+```
+
+### Methods
+
+```pascal
+procedure Queue(AProcedure: TThreadProcedure);
+procedure Queue(AMethod: TThreadMethod);
+procedure Queue(AProcedure: TThreadProcedureIndex; AIndex: Integer);
+procedure Queue(AMethod: TThreadMethodIndex; AIndex: Integer);
+procedure WaitForAll;
+procedure ClearLastError;
+```
+
+---
+
+## Usage Examples
+
+### 1. Simple procedure
+
 ```pascal
 procedure PrintHello;
 begin
-  WriteLn('Hello from thread!');
+  WriteLn('Hello from thread ', GetCurrentThreadId);
 end;
 
 begin
@@ -83,7 +152,12 @@ begin
 end;
 ```
 
-#### 2. Object Method
+### 2. Object method
+
+> **Warning:** do not free `MyObject` until after `WaitForAll` returns. Worker
+> threads hold a reference to the object's method and will crash if the object
+> is freed while they are still running.
+
 ```pascal
 type
   TMyClass = class
@@ -92,7 +166,7 @@ type
 
 procedure TMyClass.ProcessData;
 begin
-  WriteLn('Processing in thread...');
+  WriteLn('Processing in thread ', GetCurrentThreadId);
 end;
 
 var
@@ -101,93 +175,94 @@ begin
   MyObject := TMyClass.Create;
   try
     GlobalThreadPool.Queue(@MyObject.ProcessData);
-    GlobalThreadPool.WaitForAll;
+    GlobalThreadPool.WaitForAll;  // must finish before Free below
   finally
     MyObject.Free;
   end;
 end;
 ```
 
-#### 3. Indexed Operations
+### 3. Indexed procedure (loop parallelism)
+
 ```pascal
 procedure ProcessItem(index: Integer);
 begin
-  WriteLn('Processing item: ', index);
+  WriteLn('Item ', index, ' in thread ', GetCurrentThreadId);
 end;
 
 var
   i: Integer;
 begin
-  // Process items 0 to 9 in parallel
   for i := 0 to 9 do
     GlobalThreadPool.Queue(@ProcessItem, i);
-    
+
   GlobalThreadPool.WaitForAll;
 end;
 ```
 
-### 🚨 Important Notes
-
-1. **Thread Safety**
-   - Critical sections protect shared counters (Test13_ConcurrentQueueAccess)
-   - Multiple WaitForAll calls are safe (Test16_MultipleWaits)
-   - Queue operations are thread-safe (Test15_QueueAfterWait)
-   - Object lifetime is properly managed (Test17_ObjectLifetime)
-
-1. **Object Lifetime**
-   - Keep objects alive until their queued methods complete
-   - Wait for tasks to finish before freeing objects
-   - Use `try-finally` blocks for proper cleanup
-
-2. **Best Practices**
-   - Don't queue too many small tasks
-   - Consider batching small operations
-   - Use indexed operations for better task distribution
-   - Always call `WaitForAll` before accessing results
-
-### ⚠️ Common Pitfalls
+### 4. Custom pool with error check
 
 ```pascal
-// DON'T DO THIS - Object might be freed before method executes
 var
-  MyObject: TMyClass;
+  Pool: TSimpleThreadPool;
 begin
-  MyObject := TMyClass.Create;
-  GlobalThreadPool.Queue(@MyObject.ProcessData);
-  MyObject.Free;  // Wrong! Object freed too early
-end;
-
-// DO THIS INSTEAD
-var
-  MyObject: TMyClass;
-begin
-  MyObject := TMyClass.Create;
+  Pool := TSimpleThreadPool.Create(4);
   try
-    GlobalThreadPool.Queue(@MyObject.ProcessData);
-    GlobalThreadPool.WaitForAll;  // Wait for completion
+    Pool.Queue(@RiskyProcedure);
+    Pool.WaitForAll;
+
+    if Pool.LastError <> '' then
+      WriteLn('Task failed: ', Pool.LastError);
   finally
-    MyObject.Free;  // Safe to free now
+    Pool.Free;
   end;
 end;
 ```
 
-### 🔧 Advanced Usage
+---
 
-#### Custom Thread Pool
+## Common Pitfalls
+
+### Freeing an object before WaitForAll
+
 ```pascal
-var
-  CustomPool: TSimpleThreadPool;
-begin
-  // Thread count is automatically adjusted:
-  // - Minimum: 4 threads
-  // - Maximum: 2× ProcessorCount
-  // - Default: ProcessorCount (when count = 0)
-  CustomPool := TSimpleThreadPool.Create(4);
-  try
-    CustomPool.Queue(@MyProcedure);
-    CustomPool.WaitForAll;
-  finally
-    CustomPool.Free;
-  end;
+// WRONG — worker thread may still be calling MyObject.ProcessData
+MyObject := TMyClass.Create;
+GlobalThreadPool.Queue(@MyObject.ProcessData);
+MyObject.Free;  // access violation risk
+
+// CORRECT
+MyObject := TMyClass.Create;
+try
+  GlobalThreadPool.Queue(@MyObject.ProcessData);
+  GlobalThreadPool.WaitForAll;
+finally
+  MyObject.Free;
 end;
+```
+
+### Calling Free on GlobalThreadPool
+
+```pascal
+// WRONG — the unit's finalization block already does this
+GlobalThreadPool.Free;  // double-free at program exit
+
+// CORRECT — just use it; no manual cleanup needed
+GlobalThreadPool.Queue(@MyProcedure);
+GlobalThreadPool.WaitForAll;
+```
+
+### Forgetting WaitForAll
+
+```pascal
+// WRONG — program may exit before tasks finish
+for i := 0 to 99 do
+  GlobalThreadPool.Queue(@ProcessItem, i);
+// results are incomplete or uninitialized here
+
+// CORRECT
+for i := 0 to 99 do
+  GlobalThreadPool.Queue(@ProcessItem, i);
+GlobalThreadPool.WaitForAll;
+// results are now complete
 ```

--- a/docs/ThreadPool.Simple-Technical.md
+++ b/docs/ThreadPool.Simple-Technical.md
@@ -1,23 +1,22 @@
-# ThreadPool-FP Technical Documentation
+# ThreadPool.Simple — Technical Documentation
 
 ## Architecture Overview
-
 
 ```mermaid
 graph TD
     A1[Application] --> G[GlobalThreadPool]
     A2[Application] --> S[TSimpleThreadPool]
-    
+
     subgraph "Interfaces"
         ITP[IThreadPool]
         IWT[IWorkerThread]
         IWI[IWorkItem]
-        
+
         G & S -.->|implements| ITP
         W1 & W2 & Wn -.->|implements| IWT
         WI -.->|implements| IWI
     end
-    
+
     subgraph "Thread Pool"
         G & S --> |owns| TL[TThreadList]
         G & S --> |owns| WQ[TThreadList<br>Work Queue]
@@ -25,15 +24,15 @@ graph TD
         G & S --> |owns| EV[TEvent<br>Completion Signal]
         G & S --> |owns| EL[TCriticalSection<br>Error Lock]
         G & S --> |owns| EE[TEvent<br>Error Event]
-        
+
         TL --> |contains| W1[Worker Thread 1]
         TL --> |contains| W2[Worker Thread 2]
         TL --> |contains| Wn[Worker Thread n]
-        
+
         W1 & W2 & Wn -->|pop & execute| WQ
         W1 & W2 & Wn -->|report errors| EL
     end
-    
+
     subgraph "Work Items"
         P1[TThreadProcedure] --> |wrapped as| WI[TWorkItem]
         P2[TThreadMethod] --> |wrapped as| WI
@@ -43,171 +42,176 @@ graph TD
     end
 ```
 
+---
+
 ## Core Components
 
-### Thread Pool Types
+### GlobalThreadPool
 
-1. **GlobalThreadPool**
-   - Singleton instance for simple usage
-   - Automatically initialized on first use
-   - Uses default thread count based on `ProcessorCount`
-   - Suitable for most applications
-   - Thread-safe by design
+A singleton `TSimpleThreadPool` declared in the unit's `var` section.
 
-2. **TSimpleThreadPool**
-   - Custom instance creation with configurable thread count
-   - Multiple independent pools possible
-   - Full control over pool lifetime
-   - Same thread safety guarantees as `GlobalThreadPool`
-   - Useful for specialized threading scenarios
-
-Both types share the same underlying implementation and provide identical thread safety guarantees and features. The main difference is in initialization and lifetime management.
+- Created in the unit `initialization` block — available from program startup
+- Freed in the unit `finalization` block — **never call `GlobalThreadPool.Free` manually**
+- Thread count defaults to `TThread.ProcessorCount` (minimum 4)
 
 ### TSimpleThreadPool
 
-Main thread pool manager that:
+The main pool class. Responsibilities:
 
-- Maintains worker threads using `TThreadList`
-- Manages work item queue using `TThreadList`
-- Tracks work item count with `TCriticalSection`
-- Signals completion using `TEvent`
-- Provides thread-safe queueing methods
-- Handles shutdown and cleanup
-- Implements comprehensive error handling
-- Supports thread count configuration
+- Owns and manages a list of `TSimpleWorkerThread` instances (`TThreadList`)
+- Maintains a thread-safe work item queue (`TThreadList`)
+- Tracks the number of pending work items with a `TCriticalSection` + counter
+- Signals `WaitForAll` callers via a `TEvent` when the counter reaches zero
+- Captures worker exceptions thread-safely via a second `TCriticalSection`
 
-### TWorkerThread
+### TSimpleWorkerThread
 
-Worker thread implementation that:
+Each worker thread:
 
-- Inherits from `TThread`
-- Runs suspended until explicitly started
-- Continuously polls for work items
-- Executes work items when available
-- Sleeps when idle to prevent busy waiting
-- Terminates cleanly on pool shutdown
+- Is created suspended and started explicitly by the pool constructor
+- Loops continuously, popping work items from the shared queue
+- Calls `Sleep(1)` when the queue is empty to avoid busy-waiting
+- Terminates cleanly when `Terminated` is set during pool destruction
 
-### TWorkItem
+### TSimpleWorkItem
 
-Task wrapper that:
+A lightweight wrapper around one of the four task types:
 
-- Encapsulates four types of work:
-  - Simple procedures (`TThreadProcedure`)
-  - Object methods (`TThreadMethod`)
-  - Indexed procedures (`TThreadProcedureIndex`)
-  - Indexed methods (`TThreadMethodIndex`)
-- Manages task execution
-- Updates completion status
+| Type | Pascal type |
+| --- | --- |
+| Plain procedure | `TThreadProcedure` |
+| Object method | `TThreadMethod` |
+| Indexed procedure | `TThreadProcedureIndex` |
+| Indexed method | `TThreadMethodIndex` |
 
+On execution it calls the appropriate callable, then decrements the pool's pending
+counter (and signals completion if it reaches zero).
+
+---
+
+## Thread Count Rules
+
+| Condition | Result |
+| --- | --- |
+| `AThreadCount <= 0` | Uses `TThread.ProcessorCount` |
+| `AThreadCount < 4` | Raised to 4 (minimum enforced) |
+| `AThreadCount > 2 × ProcessorCount` | Clamped to `2 × ProcessorCount` |
+
+Thread count is fixed after construction — there is no dynamic scaling.
+
+### ProcessorCount limitations
+
+- `TThread.ProcessorCount` is read once at program startup
+- It may count logical CPUs (hyper-threads), not physical cores
+- It does not reflect runtime changes (e.g. CPU affinity, power states)
+- Treat it as approximate guidance, not a precise thread budget
+
+---
 
 ## Usage Patterns
 
-### 1. Basic Operations
+### 1. Basic queuing
 
 ```pascal
-// Queue a simple procedure
 GlobalThreadPool.Queue(@SimpleProcedure);
-// Queue a method
 GlobalThreadPool.Queue(@MyObject.MyMethod);
-// Queue with index
 GlobalThreadPool.Queue(@ProcessItem, 5);
+GlobalThreadPool.WaitForAll;
 ```
 
-### 2. Error Handling
+### 2. Error handling
 
 ```pascal
-try
-  GlobalThreadPool.Queue(@MyProcedure);
-  GlobalThreadPool.WaitForAll;
-  if GlobalThreadPool.LastError <> '' then
-    WriteLn('Error occurred: ', GlobalThreadPool.LastError);
-finally
-  GlobalThreadPool.Free;
+// GlobalThreadPool is managed by the unit — do NOT call Free on it.
+GlobalThreadPool.Queue(@MyProcedure);
+GlobalThreadPool.WaitForAll;
+
+if GlobalThreadPool.LastError <> '' then
+begin
+  WriteLn('Error: ', GlobalThreadPool.LastError);
+  GlobalThreadPool.ClearLastError;  // reset before reuse
 end;
 ```
 
-## Example Implementation
+### 3. Custom pool
 
-See examples in the [examples](../examples) directory.
+```pascal
+var
+  Pool: TSimpleThreadPool;
+begin
+  Pool := TSimpleThreadPool.Create(4);
+  try
+    Pool.Queue(@MyProcedure);
+    Pool.WaitForAll;
+  finally
+    Pool.Free;
+  end;
+end;
+```
+
+---
 
 ## Thread Safety
 
-The implementation uses several synchronization mechanisms:
+| Mechanism | Purpose |
+| --- | --- |
+| `TThreadList` (threads) | Safe iteration and termination of worker threads |
+| `TThreadList` (work items) | Safe enqueue / dequeue across threads |
+| `TCriticalSection` (work item count) | Atomic increment/decrement of pending counter |
+| `TEvent` (completion) | Signals `WaitForAll` when counter hits zero |
+| `TCriticalSection` (error lock) | Safe write to `FLastError` from worker threads |
 
-- `TThreadList` for thread and work item collections
-- `TCriticalSection` for work item count
-- `TEvent` for completion signaling
-- Thread-safe queue operations
-
-## Performance Considerations
-
-- Thread count is based on `TThread.ProcessorCount` (see [limitations](#system-processor-count-detection-limitations) below)
-- Sleep(1) prevents busy waiting in worker threads
-- Batch processing recommended for small tasks
-- Consider task granularity to avoid overhead
-
-## Thread Management
-
-### Thread Count Rules
-1. Minimum: 4 threads (enforced)
-2. Maximum: 2× `ProcessorCount` (strictly enforced)
-3. Default: `ProcessorCount` when count = 0 (verified by Test11_ThreadCount)
-4. Auto-adjustment of invalid values:
-   - Values < 4 are increased to 4
-   - Values > 2× `ProcessorCount` are reduced
-   - Zero defaults to `ProcessorCount`
-
-### Performance Considerations
-1. Efficient thread reuse (verified by stress tests)
-2. Safe concurrent queue access
-3. Protected counter operations
-4. Clean exception handling
-5. Proper resource cleanup
-
-
-### System Processor Count Detection Limitations
-
-- `TThread.ProcessorCount` is set once at program start
-- No guarantee whether it counts cores or CPUs
-- May not reflect dynamic system changes
-- Should be treated as approximate guidance only
-
-### Performance Considerations
-1. **Sleep Prevention**: Worker threads use `Sleep(1)` when idle
-2. **Task Granularity**: Consider overhead vs task size
-3. **Thread Count**: Default uses system processor count
-4. **Shutdown**: Clean termination of all threads
-5. **Resource Management**: Proper cleanup in destructor
+---
 
 ## Exception Handling
 
-The thread pool implements a robust exception handling system:
+### How worker exceptions are captured
 
-### Error Capture
-- Worker threads catch all exceptions
-- Error messages are stored thread-safely
-- Thread ID is included in error messages
-- Last error is accessible via `LastError` property
+```pascal
+// Inside TSimpleWorkerThread.Execute
+try
+  WorkItem.Execute;
+except
+  on E: Exception do
+  begin
+    Pool.FErrorLock.Enter;
+    try
+      Pool.SetLastError(E.Message);  // stores raw message only
+      Pool.FErrorEvent.SetEvent;
+    finally
+      Pool.FErrorLock.Leave;
+    end;
+  end;
+end;
+```
 
+### Key behaviours
 
-### Error Management
+- `LastError` stores the **raw exception message** — no thread ID prefix
+- Only the **most recent** exception is kept; earlier ones are overwritten
+- The pool **keeps running** after an exception — remaining tasks are processed
+- Call `ClearLastError` before reusing a pool to reset error state
+- Exceptions are **not re-raised** on the calling thread; check `LastError` after `WaitForAll`
 
-- Thread-safe error storage using critical sections
-- Error state can be cleared via `ClearLastError` (Test21_ExceptionAfterClear)
-- Pool continues operating after exceptions (Test20_MultipleExceptions)
-- Each new error overwrites the previous one
-- Error messages include thread identification (Test19_ExceptionMessage)
+### Best practices
 
-### Best Practices
+1. Always check `LastError` after `WaitForAll`
+2. Call `ClearLastError` before queuing a new batch if reusing the pool
+3. If you need to track all failures, collect them inside the task procedures themselves
 
-1. Check `LastError` after `WaitForAll`
-2. Clear errors before reusing the pool
-3. Consider logging persistent errors
-4. Use thread IDs to track error sources
+---
 
+## Performance Considerations
 
-### Limitations
-- Only the most recent error is stored
-- No built-in mechanism for error event handling
-- Exceptions are not propagated to the main thread
-- No implementation of an error queue
+- Workers use `Sleep(1)` when idle — low CPU overhead but ~1 ms latency before a newly queued item is picked up
+- For very large numbers of tiny tasks, consider batching them into fewer, larger work items to reduce queue overhead
+- Thread count defaults to `ProcessorCount`; raising it above that can hurt performance due to context-switching
+
+---
+
+## Limitations
+
+- Only the most recent worker exception is stored (no error queue)
+- Exceptions are not propagated to the main thread — must poll `LastError`
+- Thread count is fixed after construction — no dynamic scaling
+- No task prioritisation or cancellation

--- a/examples/ProdConSimpleDemo/ProdConSimpleDemo.lpr
+++ b/examples/ProdConSimpleDemo/ProdConSimpleDemo.lpr
@@ -54,6 +54,9 @@ begin
     WriteLn('1. Queueing simple procedure');
     Pool.Queue(@SimpleProc);
 
+    // WARNING: MyObject must NOT be freed before Pool.WaitForAll returns.
+    // Worker threads call MyObject's methods asynchronously — freeing early
+    // causes an access violation. The try/finally below ensures correct order.
     WriteLn('2. Queueing method of a class');
     Pool.Queue(@MyObject.DoSomething);
 
@@ -65,17 +68,17 @@ begin
 
     WriteLn('--------------------------------');
     WriteLn('Waiting for all tasks to complete...');
-    Pool.WaitForAll;
+    Pool.WaitForAll;  // MUST be called before freeing Pool or MyObject (see finally)
     WriteLn('--------------------------------');
     WriteLn('All tasks completed successfully!');
 
-    // Check for any errors
+    // Check for any errors — only the LAST exception is stored in LastError
     if Pool.LastError <> '' then
       WriteLn('Error occurred: ', Pool.LastError);
 
   finally
-    Pool.Free;
-    MyObject.Free;
+    Pool.Free;        // Safe: WaitForAll has already returned above
+    MyObject.Free;    // Safe: all method calls have completed
   end;
 
   // Pause console

--- a/examples/SimpleDemo/SimpleDemo.lpr
+++ b/examples/SimpleDemo/SimpleDemo.lpr
@@ -45,28 +45,31 @@ begin
   try
     WriteLn('Demo of ThreadPool functionality:');
     WriteLn('--------------------------------');
-    
+
     // Queue different types of work
     WriteLn('1. Queueing simple procedure');
     GlobalThreadPool.Queue(@SimpleProc);
-    
+
+    // WARNING: MyObject must NOT be freed before WaitForAll returns.
+    // Worker threads call MyObject's methods asynchronously — freeing early
+    // causes an access violation. The try/finally below ensures correct order.
     WriteLn('2. Queueing method of a class');
     GlobalThreadPool.Queue(@MyObject.DoSomething);
-    
+
     WriteLn('3. Queueing indexed procedure');
     GlobalThreadPool.Queue(@IndexProc, 1);
-    
+
     WriteLn('4. Queueing method with index of a class');
     GlobalThreadPool.Queue(@MyObject.DoSomethingWithIndex, 2);
 
     WriteLn('--------------------------------');
     WriteLn('Waiting for all tasks to complete...');
-    GlobalThreadPool.WaitForAll;
+    GlobalThreadPool.WaitForAll;  // MUST be called before MyObject.Free (see finally)
     WriteLn('--------------------------------');
     WriteLn('All tasks completed successfully!');
-    
+
   finally
-    MyObject.Free;
+    MyObject.Free;  // Safe: WaitForAll has already returned above
   end;
 
   // Pause console

--- a/examples/Starter/Starter.lpi
+++ b/examples/Starter/Starter.lpi
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+        <UseDefaultCompilerOptions Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="Starter"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+      <Item Name="Debug">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="Starter"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Parsing>
+            <SyntaxOptions>
+              <IncludeAssertionCode Value="True"/>
+            </SyntaxOptions>
+          </Parsing>
+          <CodeGeneration>
+            <Checks>
+              <IOChecks Value="True"/>
+              <RangeChecks Value="True"/>
+              <OverflowChecks Value="True"/>
+              <StackChecks Value="True"/>
+            </Checks>
+            <VerifyObjMethodCallValidity Value="True"/>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <DebugInfoType Value="dsDwarf3"/>
+              <UseHeaptrc Value="True"/>
+              <TrashVariables Value="True"/>
+            </Debugging>
+          </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Release">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="Starter"/>
+          </Target>
+          <SearchPaths>
+            <OtherUnitFiles Value="..\..\src"/>
+            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <CodeGeneration>
+            <SmartLinkUnit Value="True"/>
+            <Optimizations>
+              <OptimizationLevel Value="3"/>
+            </Optimizations>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <GenerateDebugInfo Value="False"/>
+              <RunWithoutDebug Value="True"/>
+              <StripSymbols Value="True"/>
+            </Debugging>
+            <LinkSmart Value="True"/>
+          </Linking>
+          <Other>
+            <CustomOptions Value="-FcUTF8"/>
+          </Other>
+        </CompilerOptions>
+      </Item>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <Units>
+      <Unit>
+        <Filename Value="Starter.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value="Starter"/>
+    </Target>
+    <SearchPaths>
+      <OtherUnitFiles Value="..\..\src"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Other>
+      <CustomOptions Value="-FcUTF8"/>
+    </Other>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ECodetoolError"/>
+      </Item>
+      <Item>
+        <Name Value="EFOpenError"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/examples/Starter/Starter.lpr
+++ b/examples/Starter/Starter.lpr
@@ -1,0 +1,84 @@
+program Starter;
+
+{ Hello, ThreadPool!
+  ==================
+  The simplest possible introduction to threadpool-fp.
+
+  HOW TO COMPILE AND RUN
+  ----------------------
+  Option A — Free Pascal compiler:
+    fpc -Fu../../src Starter.lpr && ./Starter
+
+  Option B — Lazarus IDE:
+    File > Open > Starter.lpi, then Run > Run (F9)
+
+  Option C — lazbuild (command line):
+    lazbuild Starter.lpi && ./Starter
+
+  WHAT TO EXPECT
+  --------------
+  Five items are processed in parallel. Because threads run concurrently,
+  the output lines may appear in a different order each run — that is normal
+  and is exactly the point of a thread pool.
+
+  NEXT STEPS
+  ----------
+  1. Change @ProcessItem to @MyObject.MyMethod to use an object method.
+  2. Swap GlobalThreadPool for a custom TSimpleThreadPool(N) to control
+     the number of threads.
+  3. Browse the other examples/ folders for real-world patterns.
+}
+
+{$mode objfpc}{$H+}{$J-}
+
+uses
+  Classes, SysUtils, ThreadPool.Simple;
+
+// ---------------------------------------------------------------------------
+// The work: a plain indexed procedure — the most common starting point.
+// Each call receives its own index so it knows which item to process.
+// ---------------------------------------------------------------------------
+procedure ProcessItem(index: Integer);
+begin
+  // Simulate a small amount of work
+  Sleep(10);
+  WriteLn(Format('  Item %d processed in thread %d', [index, GetCurrentThreadId]));
+end;
+
+// ---------------------------------------------------------------------------
+// Main program
+// ---------------------------------------------------------------------------
+const
+  ITEM_COUNT = 5;
+
+var
+  i: Integer;
+begin
+  WriteLn('=== Hello, ThreadPool! ===');
+  WriteLn(Format('Queuing %d items across %d worker threads...',
+    [ITEM_COUNT, GlobalThreadPool.ThreadCount]));
+  WriteLn;
+
+  // Queue all items — they will run in parallel on worker threads
+  for i := 1 to ITEM_COUNT do
+    GlobalThreadPool.Queue(@ProcessItem, i);
+
+  // Block until every queued item has finished
+  // WARNING: Never free objects used by queued tasks before this call returns.
+  GlobalThreadPool.WaitForAll;
+
+  WriteLn;
+  WriteLn('All items done!');
+
+  // Optional: check whether any task raised an exception.
+  // Only the last exception is stored — call ClearLastError to reset.
+  if GlobalThreadPool.LastError <> '' then
+  begin
+    WriteLn('At least one task failed: ', GlobalThreadPool.LastError);
+    GlobalThreadPool.ClearLastError;
+  end;
+
+  WriteLn;
+  WriteLn('Press Enter to quit...');
+  ReadLn;
+end.

--- a/release-notes-v0.5.0.md
+++ b/release-notes-v0.5.0.md
@@ -1,0 +1,64 @@
+## ThreadPool for Free Pascal — v0.5.0
+
+This release focuses on making the library easier to pick up for new Free Pascal
+developers, tightens up the documentation, and fixes three test
+failures.
+
+### What's new
+
+#### Easier onboarding
+- **New `examples/Starter/Starter.lpr`** — a single, heavily-commented file that
+  compiles and runs in under a minute. Includes `fpc`/`lazbuild` one-liners and
+  expected output directly in the header.
+- **README: decision flowchart** — a quick text tree to choose between
+  `ThreadPool.Simple` and `ThreadPool.ProducerConsumer`.
+- **README: Queue overload reference table** — all 4 `Queue` signatures
+  side-by-side with use-cases and examples.
+- **README: Common Mistakes section** — annotated before/after code pairs for the
+  four most frequent pitfalls:
+  - Freeing an object before `WaitForAll`
+  - Forgetting `WaitForAll` entirely
+  - `LastError` only storing the last exception
+  - Manually calling `Free` on `GlobalThreadPool`
+- **README: compilation sanity-check** — `fpc` and `lazbuild` one-liners with
+  expected output, plus a reminder about `{$mode objfpc}{$H+}`.
+
+#### Source readability
+- `{$REGION}` / `{$ENDREGION}` grouping added to `ThreadPool.Simple.pas` and
+  `ThreadPool.ProducerConsumer.pas` — public API, internal worker thread, work
+  item, and queue sections are now collapsible in Lazarus and VS Code.
+- Object lifetime `WARNING` comments added inline to `SimpleDemo.lpr` and
+  `ProdConSimpleDemo.lpr`.
+
+#### Documentation corrections
+- `ThreadPool.Simple-API.md`: corrected `LastError` description — stores the raw
+  exception message only, no thread-ID prefix.
+- `ThreadPool.Simple-Technical.md`: removed incorrect `GlobalThreadPool.Free`
+  from example; corrected "initialized on first use" (it is initialized at unit
+  startup); removed duplicate section heading.
+- `ThreadPool.ProducerConsumer-API.md`: added missing `WorkQueue` property;
+  fixed two code examples that caught queue-full by message string equality
+  (unreliable) — now catch `EQueueFullException` by type.
+- `ThreadPool.ProducerConsumer-Technical.md`: replaced simplified `TryEnqueue`
+  snippet (missing retry loop) with the actual implementation; replaced
+  pseudo-code `Execute` snippet with real code.
+- `Interface-Reference-Counting` doc: updated test example to use `LongTask`
+  instead of `SlowTask`, matching the fix to Test08.
+
+### Bug fixes (tests)
+
+Three test failures were present since the tests were first written — they were
+never passing, not regressions introduced in this release.
+
+| Test | Root cause | Fix |
+| --- | --- | --- |
+| `Test07_ParallelExecution` | `IncrementCounter` contained two `LogTest` (`WriteLn`) calls; 2 000 serialised console writes across 1 000 tasks consistently exceeded the timing assertion | Removed `LogTest` calls from `IncrementCounter` |
+| `Test08_QueueFullBehavior` | `SlowTask` (250 ms) was short enough for the single worker to drain the 2-slot queue before the 3rd enqueue, so `EQueueFullException` was never raised | Replaced with `LongTask` (5 000 ms) to keep the queue full long enough |
+| `Test12_LoadFactorCalculation` | `LoadFactor` is `FCount / FCapacity` — it drops to 0 the moment a worker calls `TryDequeue`, not when the task finishes. With only 2 tasks and 4+ workers, both items were dequeued before the assertion ran | Increased queued task count to 50 so the queue backlog outlasts the dequeue race |
+
+
+**All 35 tests pass, 0 errors, 0 failures.**
+
+### Full changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the complete version history.

--- a/release-notes-v0.5.0.md
+++ b/release-notes-v0.5.0.md
@@ -1,12 +1,13 @@
 ## ThreadPool for Free Pascal — v0.5.0
 
 This release focuses on making the library easier to pick up for new Free Pascal
-developers, tightens up the documentation, and fixes three test
+developers, tightens up the documentation, and fixes three long-standing test
 failures.
 
 ### What's new
 
 #### Easier onboarding
+
 - **New `examples/Starter/Starter.lpr`** — a single, heavily-commented file that
   compiles and runs in under a minute. Includes `fpc`/`lazbuild` one-liners and
   expected output directly in the header.
@@ -24,6 +25,7 @@ failures.
   expected output, plus a reminder about `{$mode objfpc}{$H+}`.
 
 #### Source readability
+
 - `{$REGION}` / `{$ENDREGION}` grouping added to `ThreadPool.Simple.pas` and
   `ThreadPool.ProducerConsumer.pas` — public API, internal worker thread, work
   item, and queue sections are now collapsible in Lazarus and VS Code.
@@ -31,17 +33,21 @@ failures.
   `ProdConSimpleDemo.lpr`.
 
 #### Documentation corrections
-- `ThreadPool.Simple-API.md`: corrected `LastError` description — stores the raw
-  exception message only, no thread-ID prefix.
+
+- `ThreadPool.Simple-API.md`: full rewrite for clarity and structure; corrected
+  `LastError` description — stores the raw exception message only, no thread-ID
+  prefix.
 - `ThreadPool.Simple-Technical.md`: removed incorrect `GlobalThreadPool.Free`
   from example; corrected "initialized on first use" (it is initialized at unit
-  startup); removed duplicate section heading.
-- `ThreadPool.ProducerConsumer-API.md`: added missing `WorkQueue` property;
-  fixed two code examples that caught queue-full by message string equality
-  (unreliable) — now catch `EQueueFullException` by type.
+  startup); removed duplicate section heading; replaced bullet lists with tables.
+- `ThreadPool.ProducerConsumer-API.md`: full rewrite for clarity; removed
+  duplicate Constructor section; fixed error handling example (`WaitForAll` was
+  incorrectly inside the `EQueueFullException` handler); added missing `WorkQueue`
+  property; fixed two examples that caught queue-full by message string equality —
+  now catch `EQueueFullException` by type.
 - `ThreadPool.ProducerConsumer-Technical.md`: replaced simplified `TryEnqueue`
   snippet (missing retry loop) with the actual implementation; replaced
-  pseudo-code `Execute` snippet with real code.
+  pseudo-code `Execute` snippet with real code; added thread safety summary table.
 - `Interface-Reference-Counting` doc: updated test example to use `LongTask`
   instead of `SlowTask`, matching the fix to Test08.
 
@@ -55,7 +61,6 @@ never passing, not regressions introduced in this release.
 | `Test07_ParallelExecution` | `IncrementCounter` contained two `LogTest` (`WriteLn`) calls; 2 000 serialised console writes across 1 000 tasks consistently exceeded the timing assertion | Removed `LogTest` calls from `IncrementCounter` |
 | `Test08_QueueFullBehavior` | `SlowTask` (250 ms) was short enough for the single worker to drain the 2-slot queue before the 3rd enqueue, so `EQueueFullException` was never raised | Replaced with `LongTask` (5 000 ms) to keep the queue full long enough |
 | `Test12_LoadFactorCalculation` | `LoadFactor` is `FCount / FCapacity` — it drops to 0 the moment a worker calls `TryDequeue`, not when the task finishes. With only 2 tasks and 4+ workers, both items were dequeued before the assertion ran | Increased queued task count to 50 so the queue backlog outlasts the dequeue race |
-
 
 **All 35 tests pass, 0 errors, 0 failures.**
 

--- a/src/threadpool.producerconsumer.pas
+++ b/src/threadpool.producerconsumer.pas
@@ -27,6 +27,7 @@ type
   end;
 
 
+  {$REGION 'Internal: Worker Thread'}
   { Worker thread implementation for producer-consumer pattern }
   TProducerConsumerWorkerThread = class(TThread)
   private
@@ -37,6 +38,9 @@ type
     constructor Create(AThreadPool: TObject);
   end;
 
+  {$ENDREGION}
+
+  {$REGION 'Internal: Thread-Safe Queue'}
   { Thread-safe circular queue for work items }
   TThreadSafeQueue = class(TObject)
   private
@@ -62,6 +66,9 @@ type
     property BackpressureConfig: TBackpressureConfig read FBackpressureConfig write FBackpressureConfig;
   end;
 
+  {$ENDREGION}
+
+  {$REGION 'Internal: Work Item'}
   { Work item implementation for producer-consumer pattern }
   TProducerConsumerWorkItem = class(TInterfacedObject, IWorkItem)
   private
@@ -79,6 +86,9 @@ type
     function GetItemType: integer;
   end;
 
+  {$ENDREGION}
+
+  {$REGION 'Public API: TProducerConsumerThreadPool'}
   { Producer-consumer thread pool implementation }
   TProducerConsumerThreadPool = class(TThreadPoolBase)
   private
@@ -109,13 +119,21 @@ type
     property LastError: string read GetLastError;
   end;
 
+  {$ENDREGION}
+
 implementation
+
+{$REGION 'DebugLog'}
 
 procedure DebugLog(const Msg: string);
 begin
   if DEBUG_LOG then
     WriteLn('[', FormatDateTime('hh:nn:ss.zzz', Now), '] ', GetThreadID, ': ', Msg);
 end;
+
+{$ENDREGION}
+
+{$REGION 'TProducerConsumerThreadPool — Public API'}
 
 constructor TProducerConsumerThreadPool.Create(AThreadCount: Integer = 0; AQueueSize: Integer = 1024);
 var
@@ -343,6 +361,10 @@ begin
   Result := inherited GetLastError;
 end;
 
+{$ENDREGION}
+
+{$REGION 'TProducerConsumerWorkItem'}
+
 { TProducerConsumerWorkItem }
 
 constructor TProducerConsumerWorkItem.Create(AThreadPool: TObject);
@@ -367,6 +389,10 @@ function TProducerConsumerWorkItem.GetItemType: integer;
 begin
   Result := Ord(FItemType);
 end;
+
+{$ENDREGION}
+
+{$REGION 'TThreadSafeQueue'}
 
 { TThreadSafeQueue }
 
@@ -469,6 +495,10 @@ begin
   end;
 end;
 
+{$ENDREGION}
+
+{$REGION 'TProducerConsumerWorkerThread'}
+
 { TProducerConsumerWorkerThread }
 
 constructor TProducerConsumerWorkerThread.Create(AThreadPool: TObject);
@@ -530,6 +560,8 @@ begin
   end;
   DebugLog('Worker thread terminating');
 end;
+
+{$ENDREGION}
 
 function TThreadSafeQueue.GetLoadFactor: Double;
 begin

--- a/src/threadpool.simple.pas
+++ b/src/threadpool.simple.pas
@@ -8,6 +8,7 @@ uses
   Classes, SysUtils, SyncObjs, ThreadPool.Types;
 
 type
+  {$REGION 'Internal: Work Item'}
   { Simple work item implementation }
   TSimpleWorkItem = class(TInterfacedObject, IWorkItem)
   private
@@ -26,8 +27,11 @@ type
     function GetItemType: Integer;
   end;
 
+  {$ENDREGION}
+
+  {$REGION 'Internal: Worker Thread'}
   { Simple worker thread implementation }
-  TSimpleWorkerThread = class(TThread, IWorkerThread) 
+  TSimpleWorkerThread = class(TThread, IWorkerThread)
   private
     FRefCount: Integer;
     FThreadPool: TObject;
@@ -46,6 +50,9 @@ type
     function _Release: Integer; stdcall;
   end;
 
+  {$ENDREGION}
+
+  {$REGION 'Public API: TSimpleThreadPool'}
   { Simple thread pool implementation }
   TSimpleThreadPool = class(TThreadPoolBase)
   private
@@ -74,13 +81,19 @@ type
     property LastError: string read GetLastError;
   end;
 
+  {$ENDREGION}
+
 var
-  { Global thread pool instance
-    Automatically created at unit initialization
-    Freed at unit finalization }
+  {$REGION 'Public API: Global instance'}
+  { Global thread pool instance.
+    Created automatically at unit initialization; freed at finalization.
+    Do NOT call GlobalThreadPool.Free — the unit manages its lifetime. }
   GlobalThreadPool: TSimpleThreadPool;
+  {$ENDREGION}
 
 implementation
+
+{$REGION 'TSimpleWorkerThread'}
 
 { TSimpleWorkerThread }
 
@@ -186,6 +199,10 @@ begin
   end;
 end;
 
+{$ENDREGION}
+
+{$REGION 'TSimpleWorkItem'}
+
 { TSimpleWorkItem }
 
 constructor TSimpleWorkItem.Create(AThreadPool: TObject);
@@ -231,6 +248,10 @@ function TSimpleWorkItem.GetItemType: Integer;
 begin
   Result := Ord(FItemType);
 end;
+
+{$ENDREGION}
+
+{$REGION 'TSimpleThreadPool — Public API'}
 
 { TSimpleThreadPool }
 
@@ -437,6 +458,8 @@ function TSimpleThreadPool.GetLastError: string;
 begin
   Result := inherited GetLastError;
 end;
+
+{$ENDREGION}
 
 initialization
   GlobalThreadPool := TSimpleThreadPool.Create;  // Create global instance

--- a/tests/threadpool.producerconsumer.tests.pas
+++ b/tests/threadpool.producerconsumer.tests.pas
@@ -82,11 +82,9 @@ end;
 
 procedure TTestProducerConsumerThreadPool.IncrementCounter;
 begin
-  LogTest('IncrementCounter called');
   FSharedLock.Enter;
   try
     Inc(FSharedCounter);
-    LogTest('Counter incremented to ' + IntToStr(FSharedCounter));
   finally
     FSharedLock.Leave;
   end;
@@ -304,15 +302,18 @@ begin
     TestPool.WorkQueue.BackpressureConfig := Config;
     
     ExceptionRaised := False;
-    
-    // Fill the queue
+
+    // Fill the queue with long-running tasks so the worker cannot drain the
+    // queue between these enqueues and the third attempt below.
+    // SlowTask (250ms) is too short — the single worker may dequeue item 1
+    // before item 3 is attempted, defeating the "full queue" condition.
     LogTest('test08: Queueing first task');
-    TestPool.Queue(@SlowTask);
+    TestPool.Queue(@LongTask);
     LogTest('test08: Queueing second task');
-    TestPool.Queue(@SlowTask);
+    TestPool.Queue(@LongTask);
 
     try
-      TestPool.Queue(@SlowTask);
+      TestPool.Queue(@LongTask);
       LogTest('ERROR: Queue succeeded when it should have been full');
     except
       on E: EQueueFullException do
@@ -410,17 +411,21 @@ end;
 procedure TTestProducerConsumerThreadPool.Test12_LoadFactorCalculation;
 var
   LoadFactor: Double;
+  I: Integer;
 begin
   LogTest('Test12_LoadFactorCalculation starting...');
-  
+
   // Empty queue
   LoadFactor := FThreadPool.WorkQueue.LoadFactor;
   AssertEquals('Empty queue load factor', 0.0, LoadFactor);
-  
-  // Add some tasks
-  FThreadPool.Queue(@SleepTask);
-  FThreadPool.Queue(@SleepTask);
-  
+
+  // Queue more tasks than there are threads so the queue buffer always has
+  // items in it when LoadFactor is read immediately after. Two SleepTask items
+  // on a multi-thread pool drain before the assertion — the workers dequeue
+  // both in < 1 ms. Queuing 50 items guarantees at least some remain.
+  for I := 1 to 50 do
+    FThreadPool.Queue(@SleepTask);
+
   LoadFactor := FThreadPool.WorkQueue.LoadFactor;
   AssertTrue('Partial queue load factor', (LoadFactor > 0.0) and (LoadFactor < 1.0));
   


### PR DESCRIPTION
## ThreadPool for Free Pascal — v0.5.0

This release focuses on making the library easier to pick up for new Free Pascal
developers, tightens up the documentation, and fixes three long-standing test
failures.

### What's new

#### Easier onboarding

- **New `examples/Starter/Starter.lpr`** — a single, heavily-commented file that
  compiles and runs in under a minute. Includes `fpc`/`lazbuild` one-liners and
  expected output directly in the header.
- **README: decision flowchart** — a quick text tree to choose between
  `ThreadPool.Simple` and `ThreadPool.ProducerConsumer`.
- **README: Queue overload reference table** — all 4 `Queue` signatures
  side-by-side with use-cases and examples.
- **README: Common Mistakes section** — annotated before/after code pairs for the
  four most frequent pitfalls:
  - Freeing an object before `WaitForAll`
  - Forgetting `WaitForAll` entirely
  - `LastError` only storing the last exception
  - Manually calling `Free` on `GlobalThreadPool`
- **README: compilation sanity-check** — `fpc` and `lazbuild` one-liners with
  expected output, plus a reminder about `{$mode objfpc}{$H+}`.

#### Source readability

- `{$REGION}` / `{$ENDREGION}` grouping added to `ThreadPool.Simple.pas` and
  `ThreadPool.ProducerConsumer.pas` — public API, internal worker thread, work
  item, and queue sections are now collapsible in Lazarus and VS Code.
- Object lifetime `WARNING` comments added inline to `SimpleDemo.lpr` and
  `ProdConSimpleDemo.lpr`.

#### Documentation corrections

- `ThreadPool.Simple-API.md`: full rewrite for clarity and structure; corrected
  `LastError` description — stores the raw exception message only, no thread-ID
  prefix.
- `ThreadPool.Simple-Technical.md`: removed incorrect `GlobalThreadPool.Free`
  from example; corrected "initialized on first use" (it is initialized at unit
  startup); removed duplicate section heading; replaced bullet lists with tables.
- `ThreadPool.ProducerConsumer-API.md`: full rewrite for clarity; removed
  duplicate Constructor section; fixed error handling example (`WaitForAll` was
  incorrectly inside the `EQueueFullException` handler); added missing `WorkQueue`
  property; fixed two examples that caught queue-full by message string equality —
  now catch `EQueueFullException` by type.
- `ThreadPool.ProducerConsumer-Technical.md`: replaced simplified `TryEnqueue`
  snippet (missing retry loop) with the actual implementation; replaced
  pseudo-code `Execute` snippet with real code; added thread safety summary table.
- `Interface-Reference-Counting` doc: updated test example to use `LongTask`
  instead of `SlowTask`, matching the fix to Test08.

### Bug fixes (tests)

Three test failures were present since the tests were first written — they were
never passing, not regressions introduced in this release.

| Test | Root cause | Fix |
| --- | --- | --- |
| `Test07_ParallelExecution` | `IncrementCounter` contained two `LogTest` (`WriteLn`) calls; 2 000 serialised console writes across 1 000 tasks consistently exceeded the timing assertion | Removed `LogTest` calls from `IncrementCounter` |
| `Test08_QueueFullBehavior` | `SlowTask` (250 ms) was short enough for the single worker to drain the 2-slot queue before the 3rd enqueue, so `EQueueFullException` was never raised | Replaced with `LongTask` (5 000 ms) to keep the queue full long enough |
| `Test12_LoadFactorCalculation` | `LoadFactor` is `FCount / FCapacity` — it drops to 0 the moment a worker calls `TryDequeue`, not when the task finishes. With only 2 tasks and 4+ workers, both items were dequeued before the assertion ran | Increased queued task count to 50 so the queue backlog outlasts the dequeue race |

**All 35 tests pass, 0 errors, 0 failures.**

### Full changelog

See [CHANGELOG.md](CHANGELOG.md) for the complete version history.
